### PR TITLE
Support detail parameter of deploy

### DIFF
--- a/index.js
+++ b/index.js
@@ -14,6 +14,7 @@ async function run() {
   const urlId = core.getInput("url_id");
   const replaceOrigin = core.getInput("replace_origin");
   const noteParam = core.getInput("note");
+  const detailParam = core.getInput("detail");
 
   const workflowName = process.env["GITHUB_WORKFLOW"];
   const runNumber = process.env["GITHUB_RUN_NUMBER"];
@@ -21,6 +22,7 @@ async function run() {
   const defaultNote = `Run #${runNumber} of workflow ${workflowName} in ${repositoryName}`;
 
   const deployNote = noteParam || defaultNote;
+  const deployDetail = detailParam || "";
 
   core.setSecret(apiKey);
 
@@ -87,6 +89,7 @@ async function run() {
 
     deployResults = SpeedCurve.deploys.createForUrls(apiKey, [urlId], {
       note: deployNote,
+      detail: deployDetail,
       force: true,
     });
 
@@ -106,6 +109,7 @@ async function run() {
 
     deployResults = await SpeedCurve.deploys.create(apiKey, [siteId], {
       note: deployNote,
+      detail: deployDetail,
       force: true,
     });
 


### PR DESCRIPTION
Thank you for providing a useful GitHub Action!! :)

## Overview

This PR is to support detail parameter of [deploy API](https://support.speedcurve.com/reference/add-a-deploy).

This action uses [speedcurve 2.0.5](https://github.com/SpeedCurve-Metrics/speedcurve-test-action/blob/main/package-lock.json#L4626), and  the speedcurve package supports detail parameter ([ref1](https://github.com/SpeedCurve-Metrics/speedcurve-cli/blob/6730490fcfc9e8e512c5dd0fd51f796707349452/src/deploys.ts#L46), [ref2](https://github.com/SpeedCurve-Metrics/speedcurve-cli/blob/6730490fcfc9e8e512c5dd0fd51f796707349452/src/deploys.ts#L111)). 

## Test Result
I tested the updated action on my repository.

https://github.com/negibokken/speedcurve-test-action/actions/runs/3546695233/jobs/5956003537